### PR TITLE
Fixed an LED pin out of bounds bug

### DIFF
--- a/03_8Led/8Led.c
+++ b/03_8Led/8Led.c
@@ -36,8 +36,7 @@ int main(void)
 			delay(100);
 			led_off(i);
 		}
-	//	delay(500);
-		for(i=8;i>=0;i--){  //make led off from right to left
+		for(i=7;i>=0;i--){  //make led off from right to left
 			led_on(i);
 			delay(100);
 			led_off(i);


### PR DESCRIPTION
The pin numbers go from 0 to 7, not 8.
Since pin 8 is existing but not wired physically to an LED, this doesn't produce an error but results in one phase of time where all LEDs are off.
